### PR TITLE
Scala 2.11 compatibility

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,6 +14,20 @@ object Build extends Build {
       .settings(general: _*)
       .settings(noPublishing: _*)
 
+  /*
+   * Add scala-xml dependency when needed (for Scala 2.11 and newer) in a robust way
+   * This mechanism supports cross-version publishing
+   */
+  private def scalaXmlModule: Setting[Seq[sbt.ModuleID]] = libraryDependencies := {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      // if scala 2.11+ is used, add dependency on scala-xml module
+      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+        libraryDependencies.value :+ "org.scala-lang.modules" %% "scala-xml" % "1.0.0"
+      case _ =>
+        libraryDependencies.value
+    }
+  }
+
   lazy val twirlApi =
     Project("twirl-api", file("twirl-api"))
       .settings(general: _*)
@@ -23,6 +37,7 @@ object Build extends Build {
           commonsLang,
           Test.specs
         ),
+        scalaXmlModule,
         crossScalaVersions := Seq("2.9.2", "2.10.3")
       )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.1


### PR DESCRIPTION
Update to sbt 0.13.1 and add (when Scala 2.11 is used) dependency on scala-xml module.
